### PR TITLE
docs: add warning about downloading Xcode.xip

### DIFF
--- a/Sources/xtool/Documentation.docc/Installation-Linux.md
+++ b/Sources/xtool/Documentation.docc/Installation-Linux.md
@@ -64,6 +64,10 @@ sudo apt-get install usbmuxd
 
 Download **Xcode 16.3** from <https://developer.apple.com/services-account/download?path=/Developer_Tools/Xcode_16.3/Xcode_16.3.xip>. Note the path where `Xcode_16.3.xip` is saved.
 
+> Warning
+>
+> The URL above requires authentication. You have to download Xcode.xip from your browser.
+
 ## Installation
 
 ### 1. Download xtool

--- a/Sources/xtool/Documentation.docc/Installation-Linux.md
+++ b/Sources/xtool/Documentation.docc/Installation-Linux.md
@@ -64,9 +64,9 @@ sudo apt-get install usbmuxd
 
 Download **Xcode 16.3** from <https://developer.apple.com/services-account/download?path=/Developer_Tools/Xcode_16.3/Xcode_16.3.xip>. Note the path where `Xcode_16.3.xip` is saved.
 
-> Warning
+> Note:
 >
-> The URL above requires authentication. You have to download Xcode.xip from your browser.
+> The URL above requires authentication. You'll be asked to log in with your Apple ID and accept the license agreement to download Xcode.
 
 ## Installation
 

--- a/Sources/xtool/Documentation.docc/Installation-Linux.md
+++ b/Sources/xtool/Documentation.docc/Installation-Linux.md
@@ -66,7 +66,7 @@ Download **Xcode 16.3** from <https://developer.apple.com/services-account/downl
 
 > Note:
 >
-> The URL above requires authentication. You'll be asked to log in with your Apple ID and accept the license agreement to download Xcode.
+> The URL above requires authentication, so make sure to visit it in your browser rather than running `curl`. You'll be asked to log in with your Apple ID and accept the license agreement to download Xcode.
 
 ## Installation
 


### PR DESCRIPTION
This PR adds warning that you cannot download the Xcode.xip from commandline.
Related issue: https://github.com/xtool-org/xtool/issues/16