### PR TITLE
Add iOS CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,4 +32,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Build
         run: |
-          xcodebuild build -skipMacroValidation -skipPackagePluginValidation -scheme XKit -destination generic/platform=iOS | xcbeautify
+          set -o pipefail \
+          && xcodebuild build \
+            -skipMacroValidation -skipPackagePluginValidation \
+            -scheme XKit -destination generic/platform=iOS \
+          | xcbeautify

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,4 +32,4 @@ jobs:
         uses: actions/checkout@v4
       - name: Build
         run: |
-          xcodebuild build -skipMacroValidation -skipPackagePluginValidation -scheme XKit -destination generic/platform=iOS
+          xcodebuild build -skipMacroValidation -skipPackagePluginValidation -scheme XKit -destination generic/platform=iOS | xcbeautify

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,3 +25,11 @@ jobs:
       - name: Build
         run: |
           swift build --product xtool
+  build-ios:
+    runs-on: macos-15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build
+        run: |
+          xcodebuild build -skipMacroValidation -skipPackagePluginValidation -scheme XKit -destination generic/platform=iOS

--- a/Sources/XKit/DeveloperServices/ASCKey.swift
+++ b/Sources/XKit/DeveloperServices/ASCKey.swift
@@ -13,6 +13,10 @@ public struct ASCKey: Sendable {
     }
 }
 
+#if os(iOS)
+#error("Dummy failure")
+#endif
+
 actor ASCJWTGenerator {
     // the duration for which we generate JWTs.
     // ASC allows a maximum of 20 minutes.

--- a/Sources/XKit/DeveloperServices/ASCKey.swift
+++ b/Sources/XKit/DeveloperServices/ASCKey.swift
@@ -13,10 +13,6 @@ public struct ASCKey: Sendable {
     }
 }
 
-#if os(iOS)
-#error("Dummy failure")
-#endif
-
 actor ASCJWTGenerator {
     // the duration for which we generate JWTs.
     // ASC allows a maximum of 20 minutes.


### PR DESCRIPTION
we CAN dogfood xtool here but

1. I don't want to add a circular dep yet
2. we need a good strategy to build and cache the SDK on CI. Might want to create an action that does this on a macOS runner.