### PR TITLE
Fix macOS category build warning

### DIFF
--- a/macOS/Support/Base.xcconfig
+++ b/macOS/Support/Base.xcconfig
@@ -6,5 +6,7 @@ ENABLE_HARDENED_RUNTIME = YES
 PRODUCT_NAME = xtool
 PRODUCT_MODULE_NAME = XToolMac
 
+INFOPLIST_KEY_LSApplicationCategoryType = public.app-category.developer-tools
+
 #include? "Private-Team.xcconfig"
 #include? "Private.xcconfig"


### PR DESCRIPTION
xcodebuild wants us to set a category for the Mac app