### PR TITLE
Support building for iOS simulator

### DIFF
--- a/Sources/PackLib/BuildSettings.swift
+++ b/Sources/PackLib/BuildSettings.swift
@@ -15,15 +15,14 @@ public struct BuildSettings: Sendable {
 
     public init(
         configuration: BuildConfiguration,
+        triple: String,
         packagePath: String = ".",
         options: [String] = []
     ) async throws {
         self.packagePath = packagePath
         self.configuration = configuration
         self.options = options
-
-        // TODO: allow customizing?
-        self.triple = "arm64-apple-ios"
+        self.triple = triple
 
         // on macOS we don't explicitly install a Swift SDK but
         // SwiftPM vends "implicit" Darwin SDKs as of Swift 6.1,


### PR DESCRIPTION
Closes #68

## On any platform

You can now do

```bash
xtool dev build --triple arm64-apple-ios-simulator [--ipa]
```

To build a .app/.ipa that works on the simulator.

## On macOS

You can do

```bash
xtool dev --simulator
```

To one-shot build-and-install on the booted simulator.