### PR TITLE
Support for logging OpenAPI responses

### DIFF
--- a/Sources/DeveloperAPI/Generated/Types.swift
+++ b/Sources/DeveloperAPI/Generated/Types.swift
@@ -5021,6 +5021,7 @@ public enum Components {
             case ios = "IOS"
             case macOs = "MAC_OS"
             case universal = "UNIVERSAL"
+            case services = "SERVICES"
         }
         /// - Remark: Generated from `#/components/schemas/CapabilityOption`.
         public struct CapabilityOption: Codable, Hashable, Sendable {

--- a/Sources/DeveloperAPI/openapi-overlay.yaml
+++ b/Sources/DeveloperAPI/openapi-overlay.yaml
@@ -23,3 +23,6 @@ actions:
   - target: '$.components.schemas.Device.properties.attributes.properties.deviceClass'
     update:
       enum: ["APPLE_VISION_PRO"]
+  - target: '$.components.schemas.BundleIdPlatform'
+    update:
+      enum: ["SERVICES"]

--- a/Sources/XKit/DeveloperServices/DeveloperServices+OpenAPI.swift
+++ b/Sources/XKit/DeveloperServices/DeveloperServices+OpenAPI.swift
@@ -17,7 +17,8 @@ extension DeveloperAPIClient {
             ),
             transport: httpClient.asOpenAPITransport,
             middlewares: [
-                auth.middleware
+                auth.middleware,
+                LoggingMiddleware(),
             ]
         )
     }
@@ -217,5 +218,41 @@ public struct DeveloperAPIASCAuthMiddleware: ClientMiddleware {
         var request = request
         request.headerFields[.authorization] = "Bearer \(jwt)"
         return try await next(request, body, baseURL)
+    }
+}
+
+struct LoggingMiddleware: ClientMiddleware {
+    static let regex: NSRegularExpression? = {
+        guard let pat = ProcessInfo.processInfo.environment["XTL_DEV_LOG"] else { return nil }
+        return try? NSRegularExpression(pattern: pat)
+    }()
+
+    func intercept(
+        _ request: HTTPRequest,
+        body: HTTPBody?,
+        baseURL: URL,
+        operationID: String,
+        next: (HTTPRequest, HTTPBody?, URL) async throws -> (HTTPResponse, HTTPBody?)
+    ) async throws -> (HTTPResponse, HTTPBody?) {
+        var (response, body) = try await next(request, body, baseURL)
+
+        guard Self.regex?.firstMatch(
+                  in: operationID,
+                  range: NSRange(operationID.startIndex..., in: operationID)
+              ) != nil
+              else { return (response, body) }
+
+        print("\n\(operationID) response status -> \(response.status)")
+
+        if let unwrapped = body {
+            let data = try await Data(collecting: unwrapped, upTo: .max)
+            // body may only be consumable once, replace it with the collected data
+            body = .init(data)
+
+            let text = String(decoding: data, as: UTF8.self)
+            print("\(operationID) response body -> \(text)")
+        }
+
+        return (response, body)
     }
 }


### PR DESCRIPTION
Allow setting `XTL_DEV_LOG` to a regex (e.g. `export XTL_DEV_LOG='profiles_.*'`) to log the responses of all matching operations

Also add `BundleIdPlatform.services` as seen [here](https://github.com/AvdLee/appstoreconnect-swift-sdk/blob/60bbc198c8d9f9992807bfebef86f45d6173a1f1/Makefile#L9)