### PR TITLE
More OpenAPI spec tweaks

### DIFF
--- a/Sources/DeveloperAPI/Generated/Types.swift
+++ b/Sources/DeveloperAPI/Generated/Types.swift
@@ -5022,6 +5022,7 @@ public enum Components {
             case macOs = "MAC_OS"
             case universal = "UNIVERSAL"
             case services = "SERVICES"
+            case macos = "MACOS"
         }
         /// - Remark: Generated from `#/components/schemas/CapabilityOption`.
         public struct CapabilityOption: Codable, Hashable, Sendable {

--- a/Sources/DeveloperAPI/Generated/Types.swift
+++ b/Sources/DeveloperAPI/Generated/Types.swift
@@ -1299,7 +1299,6 @@ public enum Components {
                 /// - Remark: Generated from `#/components/schemas/App/relationships/appAvailabilityV2`.
                 public var appAvailabilityV2: Components.Schemas.App.RelationshipsPayload.AppAvailabilityV2Payload?
                 /// - Remark: Generated from `#/components/schemas/App/relationships/inAppPurchases`.
-                @available(*, deprecated)
                 public struct InAppPurchasesPayload: Codable, Hashable, Sendable {
                     /// - Remark: Generated from `#/components/schemas/App/relationships/inAppPurchases/links`.
                     public var links: Components.Schemas.RelationshipLinks?
@@ -1358,7 +1357,6 @@ public enum Components {
                     }
                 }
                 /// - Remark: Generated from `#/components/schemas/App/relationships/inAppPurchases`.
-                @available(*, deprecated)
                 public var inAppPurchases: Components.Schemas.App.RelationshipsPayload.InAppPurchasesPayload?
                 /// - Remark: Generated from `#/components/schemas/App/relationships/subscriptionGroups`.
                 public struct SubscriptionGroupsPayload: Codable, Hashable, Sendable {

--- a/Sources/DeveloperAPI/openapi-overlay.yaml
+++ b/Sources/DeveloperAPI/openapi-overlay.yaml
@@ -3,6 +3,7 @@ info:
   title: Overlay for App Store Connect API
   version: 1.0.0
 actions:
+  # this field is required when using the private Xcode API
   - target: '$.components.schemas.BundleIdCapabilityCreateRequest.properties.data.properties.relationships'
     update:
       properties:
@@ -20,6 +21,8 @@ actions:
               required: [id, type]
           required: [data]
       required: [capability]
+  # openapi-generator expects response enums to be exhaustive. Apple's ASC OpenAPI spec
+  # misses some cases that they do, actually, return.
   - target: '$.components.schemas.Device.properties.attributes.properties.deviceClass'
     update:
       enum:

--- a/Sources/DeveloperAPI/openapi-overlay.yaml
+++ b/Sources/DeveloperAPI/openapi-overlay.yaml
@@ -22,7 +22,10 @@ actions:
       required: [capability]
   - target: '$.components.schemas.Device.properties.attributes.properties.deviceClass'
     update:
-      enum: ["APPLE_VISION_PRO"]
+      enum:
+        - APPLE_VISION_PRO
   - target: '$.components.schemas.BundleIdPlatform'
     update:
-      enum: ["SERVICES"]
+      enum:
+        - SERVICES
+        - MACOS

--- a/Sources/DeveloperAPI/openapi-overlay.yaml
+++ b/Sources/DeveloperAPI/openapi-overlay.yaml
@@ -21,6 +21,11 @@ actions:
               required: [id, type]
           required: [data]
       required: [capability]
+  # we don't use this but it triggers a deprecation warning. see:
+  # https://github.com/apple/swift-openapi-generator/issues/715
+  - target: '$.components.schemas.App.properties.relationships.properties.inAppPurchases'
+    update:
+      deprecated: false
   # openapi-generator expects response enums to be exhaustive. Apple's ASC OpenAPI spec
   # misses some cases that they do, actually, return.
   - target: '$.components.schemas.Device.properties.attributes.properties.deviceClass'

--- a/Sources/DeveloperAPI/openapi-overlay.yaml
+++ b/Sources/DeveloperAPI/openapi-overlay.yaml
@@ -36,4 +36,7 @@ actions:
     update:
       enum:
         - SERVICES
+        # the spec already declares MAC_OS but ASC sometimes seems to
+        # spell this as MACOS instead. see:
+        # https://github.com/xtool-org/xtool/issues/64
         - MACOS


### PR DESCRIPTION
- Add `BundleIdPlatform.macos` (potential fix for #64)
- Fix deprecation warnings
- Improve overlay organization