### PR TITLE
Fix changeCurrentDirectory warning

### DIFF
--- a/Sources/XToolSupport/SDKBuilder.swift
+++ b/Sources/XToolSupport/SDKBuilder.swift
@@ -330,7 +330,7 @@ struct SDKBuilder {
         guard FileManager.default.changeCurrentDirectoryPath(outDir) else {
             throw Console.Error("Could not change directory to '\(outDir)'")
         }
-        defer { FileManager.default.changeCurrentDirectoryPath(oldDirectory) }
+        defer { _ = FileManager.default.changeCurrentDirectoryPath(oldDirectory) }
 
         let inputStream = DataReader.data(readingFrom: fd.rawValue)
 


### PR DESCRIPTION
This is `discardableResult` on macOS (perhaps because it goes through objc bridging?) but not on Linux so we get a warning on the latter