### PR TITLE
Fix duplicate App ID registration

### DIFF
--- a/Sources/XKit/Utilities/ProvisioningIdentifiers.swift
+++ b/Sources/XKit/Utilities/ProvisioningIdentifiers.swift
@@ -21,8 +21,8 @@ extension ProvisioningIdentifiers {
         return identifier.split(separator: ".").dropFirst().joined(separator: ".")
     }
 
-    static func identifier(fromSanitized sanitized: String, context: SigningContext? = nil) -> String {
-        let uuid = (context?.auth.identityID ?? UUID().uuidString).split(separator: "-")[0].uppercased()
+    static func identifier(fromSanitized sanitized: String, context: SigningContext) -> String {
+        let uuid = context.auth.identityID.split(separator: "-")[0].uppercased()
         return "\(Self.idPrefix)\(uuid).\(sanitized)"
     }
 
@@ -36,7 +36,7 @@ extension ProvisioningIdentifiers {
         return sanitize(identifier: id)
     }
 
-    static func groupID(fromSanitized sanitized: String, context: SigningContext? = nil) -> DeveloperServicesAppGroup.GroupID {
+    static func groupID(fromSanitized sanitized: String, context: SigningContext) -> DeveloperServicesAppGroup.GroupID {
         .init(rawValue: "\(Self.groupPrefix)\(identifier(fromSanitized: sanitized, context: context))")
     }
 


### PR DESCRIPTION
We pull the list of App IDs in `upsertApp` to see if we already created the App ID. This broke when the user had too many App IDs, since DS returned a paginated response and we only looked at the first page.

We could paginate the whole list (as seen in #89) but that's slow. Instead, just filter the query to the expected App ID. This is a prefix search so we might still receive multiple responses, but it's much less likely that the user has like 10(? I'm not sure what the default/max pagination limit is) apps registered with the XTL-ABC.com.foo.bar prefix (they could have PlugIns but usually just a small number of them.)

This is a tentative fix for #87.