### PR TITLE
Drop the “Logging in” stage

### DIFF
--- a/Sources/XKit/Integration/IntegratedInstaller.swift
+++ b/Sources/XKit/Integration/IntegratedInstaller.swift
@@ -239,9 +239,7 @@ public actor IntegratedInstaller {
         guard let appDir = payload.implicitContents.first(where: { $0.pathExtension == "app" })
             else { throw Error.appExtractionFailed }
 
-        try await updateStage(to: "Logging in")
-
-        try await self.updateStage(to: "Preparing device")
+        try await updateStage(to: "Preparing device")
 
         // TODO: Maybe use `Connection` here instead of creating the lockdown
         // client manually?


### PR DESCRIPTION
This was vestigial, and besides the fact that we don't actually do any work in this stage, we also never update the progress here so it gets stuck at 0%.