### PR TITLE
Update PublicStaging path

### DIFF
--- a/Sources/XKit/Installation/IPAUploader.swift
+++ b/Sources/XKit/Installation/IPAUploader.swift
@@ -15,7 +15,7 @@ public final class IPAUploader: Sendable {
         case unexpectedSymlink(at: URL)
     }
 
-    private static let packagePath = URL(fileURLWithPath: "PublicStaging")
+    private static let packagePath = URL(fileURLWithPath: "/PublicStaging")
     private static let bufferSize = 1 << 20 // 1 MB
 
     public final class UploadedIPA: Sendable {


### PR DESCRIPTION
Previously this was shadowing the user's cwd path onto the device, e.g. if you were installing from `/home/foo/bar` it would create `/home/foo/bar/PublicStaging` on the device. For uniformity with other tools like `ideviceinstaller`, clean this up and just create `/PublicStaging`.