### PR TITLE
Handle static xcframeworks not being unpacked

### DIFF
--- a/Sources/PackLib/Packer.swift
+++ b/Sources/PackLib/Packer.swift
@@ -147,7 +147,11 @@ public struct Packer: Sendable {
                     let src = URL(fileURLWithPath: "\(name).framework/\(name)", relativeTo: binDir)
                     let magic = Data("!<arch>\n".utf8)
                     let thinMagic = Data("!<thin>\n".utf8)
-                    let bytes = try FileHandle(forReadingFrom: src).read(upToCount: magic.count)
+                    guard let bytes = try? FileHandle(forReadingFrom: src).read(upToCount: magic.count) else {
+                        // if we can't find the binary, it might be a static framework that SwiftPM
+                        // did not copy into the .build directory. we don't need to pack it anyway.
+                        break
+                    }
                     // if the magic matches one of these it's a static archive; don't embed it.
                     // https://github.com/apple/llvm-project/blob/e716ff14c46490d2da6b240806c04e2beef01f40/llvm/include/llvm/Object/Archive.h#L33
                     // swiftlint:disable:previous line_length

--- a/Sources/XToolSupport/XTool.swift
+++ b/Sources/XToolSupport/XTool.swift
@@ -66,6 +66,10 @@ extension ParsableCommand where Self: SendableMetatype {
                 print("Cancelled.")
                 self.exit()
             } catch {
+                if ProcessInfo.processInfo.environment["XTL_DEBUG_ERRORS"] != nil {
+                    print("ERROR DETAILS:")
+                    print(String(reflecting: error))
+                }
                 self.exit(withError: error)
             }
         }


### PR DESCRIPTION
SwiftPM may not unpack static xcframeworks. Handle this gracefully, if SwiftPM doesn't need the framework we don't either.

Fixes #155.