### PR TITLE
Bump device versions to fix #25

### DIFF
--- a/Sources/XKit/GrandSlam/Anisette/DeviceInfo+Fetching.swift
+++ b/Sources/XKit/GrandSlam/Anisette/DeviceInfo+Fetching.swift
@@ -91,7 +91,7 @@ extension DeviceInfo {
             romAddress: "94f6a300e9a0",
             mlbSerialNumber: "C02520301W0GF2D1U",
             serialNumber: "C02PQKRJG8WP",
-            modelID: "MacBookPro11,5"
+            modelID: "Mac16,1"
         )
     }
 }

--- a/Sources/XKit/GrandSlam/Anisette/DeviceInfo.swift
+++ b/Sources/XKit/GrandSlam/Anisette/DeviceInfo.swift
@@ -17,8 +17,8 @@ public struct DeviceInfo: Codable, Sendable {
     public static let xcodeVersion = "14.2 (14C18)"
 
     public struct ClientInfo: Codable {
-        public static let macOSVersion = "10.14.6"
-        public static let macOSBuild = "18G103"
+        public static let macOSVersion = "14.3.1"
+        public static let macOSBuild = "23D60"
 
         public static let authKitVersion = "1"
         public static let akdVersion = "1.0"


### PR DESCRIPTION
```xml
<xmlui >
  <alert
  title="Can’t Use Your Apple ID on This Device" message="Your Apple ID can only be used on devices running iOS 16.2 or later, or macOS 13.1 or later. This MacBook Pro can&apos;t be updated to the latest software.">
    <button name="ak-button" ak-action="cancel">OK</button>
  </alert>
</xmlui>
```

Fixed by using newer versions and build. In case old macbooks not supported, also bump model id