### PR TITLE
Clean up some entitlements code

### DIFF
--- a/Sources/XKit/DeveloperServices/App IDs/Entitlements/DeveloperServicesCapability.swift
+++ b/Sources/XKit/DeveloperServices/App IDs/Entitlements/DeveloperServicesCapability.swift
@@ -23,6 +23,16 @@ public struct DeveloperServicesCapability: Sendable, Hashable {
         self.isFree = isFree
         self.settings = settings
     }
+
+    public init(
+        rawName: String,
+        isFree: Bool,
+        settings: [Components.Schemas.CapabilitySetting]? = nil
+    ) {
+        self.capabilityType = .init(value2: rawName)
+        self.isFree = isFree
+        self.settings = settings
+    }
 }
 
 protocol EntitlementWithCapability: Entitlement {

--- a/Sources/XKit/Model/Entitlements/EntitlementTypes.swift
+++ b/Sources/XKit/Model/Entitlements/EntitlementTypes.swift
@@ -33,7 +33,6 @@ extension EntitlementContainer {
 
 public struct ApplicationIdentifierEntitlement: Entitlement, RawRepresentable {
     public static let identifier = "application-identifier"
-    public static let isFree = true
 
     public var rawValue: String
     public init(rawValue: String) { self.rawValue = rawValue }
@@ -41,7 +40,6 @@ public struct ApplicationIdentifierEntitlement: Entitlement, RawRepresentable {
 
 public struct TeamIdentifierEntitlement: Entitlement, RawRepresentable {
     public static let identifier = "com.apple.developer.team-identifier"
-    public static let isFree = true
 
     public var rawValue: String
     public init(rawValue: String) { self.rawValue = rawValue }
@@ -49,7 +47,6 @@ public struct TeamIdentifierEntitlement: Entitlement, RawRepresentable {
 
 public struct KeychainAccessGroupsEntitlement: Entitlement, RawRepresentable {
     public static let identifier = "keychain-access-groups"
-    public static let isFree = true
 
     public var rawValue: [String]
     public init(rawValue: [String]) { self.rawValue = rawValue }
@@ -66,10 +63,6 @@ public struct KeychainAccessGroupsEntitlement: Entitlement, RawRepresentable {
 
 public struct AppGroupEntitlement: Entitlement, RawRepresentable {
     public static let identifier = "com.apple.security.application-groups"
-    // FIXME: Enable app groups on free accounts
-    // but first we need to fix the bug where it only assigns one
-    // app group even if the ents say there are multiple
-    public static let isFree = false
 
     public var rawValue: [DeveloperServicesAppGroup.GroupID]
     public init(rawValue: [DeveloperServicesAppGroup.GroupID]) { self.rawValue = rawValue }
@@ -85,7 +78,6 @@ public struct AppGroupEntitlement: Entitlement, RawRepresentable {
 
 public struct GetTaskAllowEntitlement: Entitlement, RawRepresentable {
     public static let identifier = "get-task-allow"
-    public static let isFree = true
 
     public var rawValue: Bool
     public init(rawValue: Bool) { self.rawValue = rawValue }
@@ -93,7 +85,6 @@ public struct GetTaskAllowEntitlement: Entitlement, RawRepresentable {
 
 public struct AssociatedDomainsEntitlement: Entitlement, RawRepresentable {
     public static let identifier = "com.apple.developer.associated-domains"
-    public static let isFree = false
 
     public var rawValue: [String]
     public init(rawValue: [String]) { self.rawValue = rawValue }
@@ -109,7 +100,6 @@ public struct AssociatedDomainsEntitlement: Entitlement, RawRepresentable {
 
 public enum APSEnvironmentEntitlement: String, Entitlement {
     public static let identifier = "aps-environment"
-    public static let isFree = false
 
     case development
     case production
@@ -117,7 +107,6 @@ public enum APSEnvironmentEntitlement: String, Entitlement {
 
 public enum DataProtectionEntitlement: String, Entitlement {
     public static let identifier = "com.apple.developer.default-data-protection"
-    public static let isFree = true
 
     case complete = "NSFileProtectionComplete"
     case unlessOpen = "NSFileProtectionCompleteUnlessOpen"
@@ -126,7 +115,6 @@ public enum DataProtectionEntitlement: String, Entitlement {
 
 public struct NetworkExtensionEntitlement: Entitlement, RawRepresentable {
     public static let identifier = "com.apple.developer.networking.networkextension"
-    public static let isFree = false
 
     public var rawValue: Bool
     public init(rawValue: Bool) { self.rawValue = rawValue }
@@ -134,7 +122,6 @@ public struct NetworkExtensionEntitlement: Entitlement, RawRepresentable {
 
 public struct MultipathEntitlement: Entitlement, RawRepresentable {
     public static let identifier = "com.apple.developer.networking.multipath"
-    public static let isFree = false
 
     public var rawValue: Bool
     public init(rawValue: Bool) { self.rawValue = rawValue }
@@ -142,7 +129,6 @@ public struct MultipathEntitlement: Entitlement, RawRepresentable {
 
 public struct VPNConfigurationEntitlement: Entitlement, RawRepresentable {
     public static let identifier = "com.apple.networking.vpn.configuration"
-    public static let isFree = false
 
     public var rawValue: Bool
     public init(rawValue: Bool) { self.rawValue = rawValue }
@@ -150,7 +136,6 @@ public struct VPNConfigurationEntitlement: Entitlement, RawRepresentable {
 
 public struct SiriKitEntitlement: Entitlement, RawRepresentable {
     public static let identifier = "com.apple.developer.siri"
-    public static let isFree = false
 
     public var rawValue: Bool
     public init(rawValue: Bool) { self.rawValue = rawValue }
@@ -158,7 +143,6 @@ public struct SiriKitEntitlement: Entitlement, RawRepresentable {
 
 public struct InterAppAudioEntitlement: Entitlement, RawRepresentable {
     public static let identifier = "inter-app-audio"
-    public static let isFree = true
 
     public var rawValue: Bool
     public init(rawValue: Bool) { self.rawValue = rawValue }
@@ -166,7 +150,6 @@ public struct InterAppAudioEntitlement: Entitlement, RawRepresentable {
 
 public struct WirelessAccessoryEntitlement: Entitlement, RawRepresentable {
     public static let identifier = "com.apple.external-accessory.wireless-configuration"
-    public static let isFree = true
 
     public var rawValue: Bool
     public init(rawValue: Bool) { self.rawValue = rawValue }
@@ -174,7 +157,6 @@ public struct WirelessAccessoryEntitlement: Entitlement, RawRepresentable {
 
 public struct HomeKitEntitlement: Entitlement, RawRepresentable {
     public static let identifier = "com.apple.developer.homekit"
-    public static let isFree = true
 
     public var rawValue: Bool
     public init(rawValue: Bool) { self.rawValue = rawValue }
@@ -182,7 +164,6 @@ public struct HomeKitEntitlement: Entitlement, RawRepresentable {
 
 public struct HealthKitEntitlement: Entitlement, RawRepresentable {
     public static let identifier = "com.apple.developer.healthkit"
-    public static let isFree = true
 
     public var rawValue: Bool
     public init(rawValue: Bool) { self.rawValue = rawValue }


### PR DESCRIPTION
- We already do the `isFree` declarations in `DeveloperServiceCapability.swift`. Don't need to duplicate it on the entitlement types.
- Add support for creating capabilities with raw names