### PR TITLE
fix: sourcekit-lsp config when using binary targets

### DIFF
--- a/Sources/XToolSupport/NewCommand.swift
+++ b/Sources/XToolSupport/NewCommand.swift
@@ -125,7 +125,8 @@ struct NewCommand: AsyncParsableCommand {
                 """
                 {
                     "swiftPM": {
-                        "swiftSDK": "arm64-apple-ios"
+                        "swiftSDK": "arm64-apple-ios",
+                        "swiftCompilerFlags": ["-F", "./xtool/\(moduleName).app/Frameworks"]
                     }
                 }
                 """


### PR DESCRIPTION
When using dependencies which have `.binaryTarget` sourcekit lsp is not able to resolve imports to those dependencies. Adding the `-F` swift compiler flag makes import resolution to work