### PR TITLE
fix(linux): use home cache dir to avoid tmpfs→ext4 EINVAL on SDK install

### DIFF
--- a/Sources/XUtils/TemporaryDirectory.swift
+++ b/Sources/XUtils/TemporaryDirectory.swift
@@ -70,7 +70,18 @@ private struct TemporaryDirectoryRoot {
         if let tmpdir = env["XTL_TMPDIR"] ?? env["TMPDIR"] {
             base = URL(fileURLWithPath: tmpdir)
         } else {
+            #if os(Linux)
+            // On Linux, /tmp is commonly a tmpfs mount while ~/.swiftpm lives on ext4.
+            // Foundation's FileManager.copyItem uses sendfile(2) internally, which returns
+            // EINVAL when copying between different filesystem types (e.g. tmpfs → ext4).
+            // This causes `swift sdk install` to fail on distros like Linux Mint (#181).
+            // Using a cache dir on the home filesystem avoids the cross-fs copy entirely.
+            let xdgCache = env["XDG_CACHE_HOME"].map { URL(fileURLWithPath: $0) }
+                ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".cache")
+            base = xdgCache.appendingPathComponent("xtool")
+            #else
             base = FileManager.default.temporaryDirectory
+            #endif
         }
 
         let url = base.appendingPathComponent("sh.xtool")

--- a/Sources/XUtils/TemporaryDirectory.swift
+++ b/Sources/XUtils/TemporaryDirectory.swift
@@ -65,10 +65,10 @@ private struct TemporaryDirectoryRoot {
     }
 
     private init() {
-        let base: URL
+        let url: URL
         let env = ProcessInfo.processInfo.environment
         if let tmpdir = env["XTL_TMPDIR"] ?? env["TMPDIR"] {
-            base = URL(fileURLWithPath: tmpdir).appendingPathComponent("sh.xtool")
+            url = URL(fileURLWithPath: tmpdir).appendingPathComponent("sh.xtool")
         } else {
             #if os(Linux)
             // On Linux, /tmp is commonly a tmpfs mount while ~/.swiftpm lives on ext4.
@@ -78,13 +78,11 @@ private struct TemporaryDirectoryRoot {
             // Using a cache dir on the home filesystem avoids the cross-fs copy entirely.
             let xdgCache = env["XDG_CACHE_HOME"].map { URL(fileURLWithPath: $0) }
                 ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".cache")
-            base = xdgCache.appendingPathComponent("xtool")
+            url = xdgCache.appendingPathComponent("xtool")
             #else
-            base = FileManager.default.temporaryDirectory.appendingPathComponent("sh.xtool")
+            url = FileManager.default.temporaryDirectory.appendingPathComponent("sh.xtool")
             #endif
         }
-
-        let url = base
         try? FileManager.default.removeItem(at: url)
         do {
             try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)

--- a/Sources/XUtils/TemporaryDirectory.swift
+++ b/Sources/XUtils/TemporaryDirectory.swift
@@ -68,7 +68,7 @@ private struct TemporaryDirectoryRoot {
         let base: URL
         let env = ProcessInfo.processInfo.environment
         if let tmpdir = env["XTL_TMPDIR"] ?? env["TMPDIR"] {
-            base = URL(fileURLWithPath: tmpdir)
+            base = URL(fileURLWithPath: tmpdir).appendingPathComponent("sh.xtool")
         } else {
             #if os(Linux)
             // On Linux, /tmp is commonly a tmpfs mount while ~/.swiftpm lives on ext4.
@@ -80,11 +80,11 @@ private struct TemporaryDirectoryRoot {
                 ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".cache")
             base = xdgCache.appendingPathComponent("xtool")
             #else
-            base = FileManager.default.temporaryDirectory
+            base = FileManager.default.temporaryDirectory.appendingPathComponent("sh.xtool")
             #endif
         }
 
-        let url = base.appendingPathComponent("sh.xtool")
+        let url = base
         try? FileManager.default.removeItem(at: url)
         do {
             try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)


### PR DESCRIPTION
## Problem

`xtool setup` fails on Linux Mint (and other distros) with:

```
Error: Error Domain=NSCocoaErrorDomain Code=512 "(null)" UserInfo={
  NSUserStringVariant=["Copy"],
  NSSourceFilePathErrorKey=/tmp/sh.xtool/tmp-DarwinSDKBuild-.../darwin.artifactbundle/...,
  NSDestinationFilePath=/home/<user>/.swiftpm/swift-sdks/darwin.artifactbundle/...,
  NSUnderlyingError=Error Domain=NSPOSIXErrorDomain Code=22 "Invalid argument"
}
```

## Root Cause

On Linux Mint (and Ubuntu-based distros), `/tmp` is mounted as **tmpfs** while the home directory is on **ext4**. Foundation's `FileManager.copyItem` uses `sendfile(2)` internally, which returns `EINVAL (22)` when copying between different filesystem types.

`TemporaryDirectoryRoot` defaults to `FileManager.default.temporaryDirectory` → `/tmp` on Linux. When `swift sdk install` copies the built SDK from `/tmp/sh.xtool/...` to `~/.swiftpm/swift-sdks/`, it crosses filesystem boundaries and fails.

## Fix

On Linux, default the temp directory root to `$XDG_CACHE_HOME/xtool` (falling back to `~/.cache/xtool`) instead of `/tmp`. This keeps the build directory and install destination on the same filesystem, so the copy always succeeds.

- `$XTL_TMPDIR` and `$TMPDIR` overrides continue to work as before
- macOS behaviour is unchanged
- Follows XDG Base Directory Specification

## Changes

One file, `Sources/XUtils/TemporaryDirectory.swift` — 11 lines added inside a `#if os(Linux)` block.

Fixes #181