### PR TITLE
docs: enable copy-to-clipboard

### DIFF
--- a/Documentation/build.sh
+++ b/Documentation/build.sh
@@ -22,4 +22,5 @@ else
 fi
 
 "$docc" "$command" xtool.docc \
+    --enable-experimental-code-block-annotations \
     --experimental-enable-custom-templates


### PR DESCRIPTION
Ref https://github.com/swiftlang/swift-docc/pull/1273

Could be a good idea to later add `nocopy` to some of the code blocks that aren't commands