### PR TITLE
gsa: fix auth again

### DIFF
--- a/Sources/XKit/GrandSlam/Anisette/DeviceInfo.swift
+++ b/Sources/XKit/GrandSlam/Anisette/DeviceInfo.swift
@@ -21,12 +21,12 @@ public struct DeviceInfo: Codable, Sendable {
 
         var clientString: String {
             """
-            <\(modelID)> <macOS;26.6;25G72> <com.apple.AuthKit/1 (com.apple.dt.Xcode/26.0)>
+            <\(modelID)> <macOS;27.0;26A5378j> <com.apple.AuthKit/1 (com.apple.akd/1.0)>
             """
         }
 
         var userAgent: String {
-            "AuthKit/1 (Macintosh; OS X 26.6) (com.apple.dt.Xcode/26.0)"
+            "AuthKit/1 (Macintosh; OS X 27.0) (com.apple.dt.Xcode/26.5)"
         }
 
         public init(modelID: String) {

--- a/Sources/XKit/GrandSlam/Lookup/GrandSlamLookupManager.swift
+++ b/Sources/XKit/GrandSlam/Lookup/GrandSlamLookupManager.swift
@@ -39,6 +39,7 @@ actor GrandSlamLookupManager {
         } */
         var request = HTTPRequest(url: Self.lookupURL)
         request.headerFields = [
+            .userAgent: deviceInfo.clientInfo.userAgent,
             .init(DeviceInfo.clientInfoKey)!: deviceInfo.clientInfo.clientString,
             .init(DeviceInfo.deviceIDKey)!: deviceInfo.deviceID,
             .init(AnisetteData.iLocaleKey)!: Locale.current.identifier,


### PR DESCRIPTION
## What does this PR do?

Fixes HTTP 503 on GsService… again (followup from #244)

Seems like GSA has stopped accepting `com.apple.dt.Xcode` in the client info string. Use `akd` instead.

## How was it tested?

- [x] Logging in before failed
- [x] Logging in after succeeds

## AI tool usage

How much of this PR was AI-assisted? (check one)

- [x] **0** - No AI was used to write code
- [ ] **1** - I was assisted by AI. I reviewed the finished result.
- [ ] **2** - I set the AI going and left it to it; nobody has read the result - no review, or AI review only

<!-- If an AI agent is filling this in: declare the level honestly, and open as a draft if it is #2. Do not lower the declared level to get the PR reviewed. -->
